### PR TITLE
feat: remove const generic chunk size; add vad builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444d8748011b93cb168770e8092458cb0f8854f931ff82fdf6ddfbd72a9c933e"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563b3b88238ec95680aef36bdece66896eaa7ce3c0f1b4f39d38fb2435261352"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +886,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "typed-builder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ndarray = "0.15.6"
 ort = "2.0.0-alpha.4"
 pin-project = "1.1.3"
 thiserror = "1.0.56"
+typed-builder = "0.18.1"
 
 [dev-dependencies]
 hound = "3.5.1"

--- a/README.md
+++ b/README.md
@@ -8,31 +8,22 @@ This crate provides a standalone Voice Activity Detector (VAD) which can be used
 
 The VAD predicts speech in a chunk of Linear Pulse Code Modulation (LPCM) encoded audio samples. These may be 8 or 16 bit integers or 32 bit floats.
 
-The model is trained using chunk sizes of 256, 512, and 768 samples for an 8000 hz sample rate. It is trained using chunk sizes of 512, 768, 1024 samples for a 16,000 hz sample rate. These values are recommended for optimal performance, but are not required.
+The model is trained using chunk sizes of 256, 512, and 768 samples for an 8000 hz sample rate. It is trained using chunk sizes of 512, 768, 1024 samples for a 16,000 hz sample rate. These values are recommended for optimal performance, but are not required. The only requirement imposed by the underlying model is the sample rate must be no larger than 31.25 times the chunk size.
+
+The samples passed to `predict` will be truncacted or padded if they are not of the correct length.
 
 ```rust
 fn main() -> Result<(), voice_activity_detector::Error> {
     use voice_activity_detector::{VoiceActivityDetector};
 
     let chunk = vec![0i16; 512];
-    let mut vad = VoiceActivityDetector::<512>::try_with_sample_rate(8000)?;
+    let mut vad = VoiceActivityDetector::builder()
+        .sample_rate(8000)
+        .chunk_size(512usize)
+        .build()?;
     let probability = vad.predict(chunk);
     println!("probability: {}", probability);
 
-    Ok(())
-}
-```
-
-The samples passed to `predict` will be truncacted or padded if they are not of the correct length. If you would like to ensure this does not happen, you must check the lengths of your inputs or use the `predict_array` function.
-
-```rust
-fn main() -> Result<(), voice_activity_detector::Error> {
-    use voice_activity_detector::{VoiceActivityDetector};
-
-    let chunk = [0i16; 512];
-    let mut vad = VoiceActivityDetector::<512>::try_with_sample_rate(8000)?;
-    let probability = vad.predict_array(chunk);
-    println!("probability: {}", probability);
     Ok(())
 }
 ```
@@ -52,7 +43,10 @@ fn main() -> Result<(), voice_activity_detector::Error> {
     use voice_activity_detector::{IteratorExt, VoiceActivityDetector};
 
     let samples = [0i16; 512000];
-    let vad = VoiceActivityDetector::<512>::try_with_sample_rate(8000)?;
+    let vad = VoiceActivityDetector::builder()
+        .sample_rate(8000)
+        .chunk_size(512usize)
+        .build()?;
 
     let probabilities = samples.into_iter().predict(vad);
     for (chunk, probability) in probabilities {
@@ -77,7 +71,10 @@ fn main() -> Result<(), voice_activity_detector::Error> {
     use voice_activity_detector::{LabeledAudio, IteratorExt, VoiceActivityDetector};
 
     let samples = [0i16; 51200];
-    let vad = VoiceActivityDetector::<512>::try_with_sample_rate(8000)?;
+    let vad = VoiceActivityDetector::builder()
+        .sample_rate(8000)
+        .chunk_size(512usize)
+        .build()?;
 
     // This will label any audio chunks with a probability greater than 75% as speech,
     // and label the 3 additional chunks before and after these chunks as speech.

--- a/src/iterator/extension.rs
+++ b/src/iterator/extension.rs
@@ -5,10 +5,7 @@ use crate::{LabelIterator, PredictIterator, Sample, VoiceActivityDetector};
 /// Extensions for iterators.
 pub trait IteratorExt: Iterator {
     /// Creates a new [PredictIterator] from an iterator of samples.
-    fn predict<const N: usize>(
-        self,
-        vad: VoiceActivityDetector<N>,
-    ) -> PredictIterator<Self::Item, Self, N>
+    fn predict(self, vad: VoiceActivityDetector) -> PredictIterator<Self::Item, Self>
     where
         Self::Item: Sample,
         Self: Sized,
@@ -20,12 +17,12 @@ pub trait IteratorExt: Iterator {
     }
 
     /// Creates a new [LabelIterator] from an iterator of samples.
-    fn label<const N: usize>(
+    fn label(
         self,
-        vad: VoiceActivityDetector<N>,
+        vad: VoiceActivityDetector,
         threshold: f32,
         padding_chunks: usize,
-    ) -> LabelIterator<Self::Item, Self, N>
+    ) -> LabelIterator<Self::Item, Self>
     where
         Self::Item: Sample,
         Self: Sized,

--- a/src/iterator/label.rs
+++ b/src/iterator/label.rs
@@ -3,20 +3,20 @@ use crate::{PredictIterator, Sample};
 
 /// Labels an iterator of speech samples as either speech or non-speech according
 /// to the provided speech sensitity.
-pub struct LabelIterator<T, I, const N: usize>
+pub struct LabelIterator<T, I>
 where
     I: Iterator,
 {
-    pub(super) iter: PredictIterator<T, I, N>,
-    pub(super) state: LabelState<T, N>,
+    pub(super) iter: PredictIterator<T, I>,
+    pub(super) state: LabelState<T>,
 }
 
-impl<T, I, const N: usize> Iterator for LabelIterator<T, I, N>
+impl<T, I> Iterator for LabelIterator<T, I>
 where
     T: Sample,
     I: Iterator<Item = T>,
 {
-    type Item = LabeledAudio<T, N>;
+    type Item = LabeledAudio<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(buffered) = self.state.try_buffer() {

--- a/src/iterator/predict.rs
+++ b/src/iterator/predict.rs
@@ -2,20 +2,20 @@ use crate::predict::PredictState;
 use crate::Sample;
 
 /// Predicts speech in an iterator of audio samples.
-pub struct PredictIterator<T, I, const N: usize>
+pub struct PredictIterator<T, I>
 where
     I: Iterator,
 {
     pub(super) iter: I,
-    pub(super) state: PredictState<T, N>,
+    pub(super) state: PredictState<T>,
 }
 
-impl<T, I, const N: usize> Iterator for PredictIterator<T, I, N>
+impl<T, I> Iterator for PredictIterator<T, I>
 where
     T: Sample,
     I: Iterator<Item = T>,
 {
-    type Item = ([T; N], f32);
+    type Item = (Vec<T>, f32);
 
     fn next(&mut self) -> Option<Self::Item> {
         for sample in self.iter.by_ref() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub use label::LabeledAudio;
 pub use sample::Sample;
 #[cfg(feature = "async")]
 pub use stream::{LabelStream, PredictStream, StreamExt};
-pub use vad::VoiceActivityDetector;
+pub use vad::{VoiceActivityDetector, VoiceActivityDetectorBuilder};

--- a/src/stream/extension.rs
+++ b/src/stream/extension.rs
@@ -7,10 +7,7 @@ use crate::{LabelStream, PredictStream, Sample, VoiceActivityDetector};
 /// Extensions for streams.
 pub trait StreamExt: Stream {
     /// Creates a new [PredictStream] from a stream of samples.
-    fn predict<const N: usize>(
-        self,
-        vad: VoiceActivityDetector<N>,
-    ) -> PredictStream<Self::Item, Self, N>
+    fn predict(self, vad: VoiceActivityDetector) -> PredictStream<Self::Item, Self>
     where
         Self::Item: Sample,
         Self: Sized,
@@ -22,12 +19,12 @@ pub trait StreamExt: Stream {
     }
 
     /// Creates a new [LabelStream] from an iterator of samples.
-    fn label<const N: usize>(
+    fn label(
         self,
-        vad: VoiceActivityDetector<N>,
+        vad: VoiceActivityDetector,
         threshold: f32,
         padding_chunks: usize,
-    ) -> LabelStream<Self::Item, Self, N>
+    ) -> LabelStream<Self::Item, Self>
     where
         Self::Item: Sample,
         Self: Sized,

--- a/src/stream/label.rs
+++ b/src/stream/label.rs
@@ -9,21 +9,21 @@ use crate::{PredictStream, Sample};
 /// Labels a stream of speech samples as either speech or non-speech according
 /// to the provided speech sensitity.
 #[pin_project]
-pub struct LabelStream<T, St, const N: usize>
+pub struct LabelStream<T, St>
 where
     St: Stream,
 {
     #[pin]
-    pub(super) stream: PredictStream<T, St, N>,
-    pub(super) state: LabelState<T, N>,
+    pub(super) stream: PredictStream<T, St>,
+    pub(super) state: LabelState<T>,
 }
 
-impl<T, St, const N: usize> Stream for LabelStream<T, St, N>
+impl<T, St> Stream for LabelStream<T, St>
 where
     T: Sample,
     St: Stream<Item = T>,
 {
-    type Item = LabeledAudio<T, N>;
+    type Item = LabeledAudio<T>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/src/stream/predict.rs
+++ b/src/stream/predict.rs
@@ -8,21 +8,21 @@ use crate::Sample;
 
 /// Predicts speech in a stream of audio samples.
 #[pin_project]
-pub struct PredictStream<T, St, const N: usize>
+pub struct PredictStream<T, St>
 where
     St: Stream,
 {
     #[pin]
     pub(super) stream: St,
-    pub(super) state: PredictState<T, N>,
+    pub(super) state: PredictState<T>,
 }
 
-impl<T, St, const N: usize> Stream for PredictStream<T, St, N>
+impl<T, St> Stream for PredictStream<T, St>
 where
     T: Sample,
     St: Stream<Item = T>,
 {
-    type Item = ([T; N], f32);
+    type Item = (Vec<T>, f32);
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/tests/file_label_iterator.rs
+++ b/tests/file_label_iterator.rs
@@ -12,7 +12,10 @@ fn wave_file_label_iterator() -> Result<(), Box<dyn Error>> {
     let mut speech = hound::WavWriter::create("tests/.outputs/label.iter.speech.wav", spec)?;
     let mut nonspeech = hound::WavWriter::create("tests/.outputs/label.iter.nonspeech.wav", spec)?;
 
-    let vad = VoiceActivityDetector::<256>::try_with_sample_rate(spec.sample_rate)?;
+    let vad = VoiceActivityDetector::builder()
+        .chunk_size(256usize)
+        .sample_rate(spec.sample_rate)
+        .build()?;
 
     let chunks = reader
         .samples::<i16>()

--- a/tests/file_label_stream.rs
+++ b/tests/file_label_stream.rs
@@ -12,7 +12,10 @@ async fn wave_file_label_iterator() -> Result<(), Box<dyn std::error::Error>> {
     let mut nonspeech =
         hound::WavWriter::create("tests/.outputs/label.stream.nonspeech.wav", spec)?;
 
-    let vad = VoiceActivityDetector::<256>::try_with_sample_rate(spec.sample_rate)?;
+    let vad = VoiceActivityDetector::builder()
+        .chunk_size(256usize)
+        .sample_rate(spec.sample_rate)
+        .build()?;
 
     let chunks = reader.samples::<i16>().map_while(Result::ok);
 

--- a/tests/file_predict_iterator.rs
+++ b/tests/file_predict_iterator.rs
@@ -11,7 +11,10 @@ fn wave_file_predict_iterator() -> Result<(), Box<dyn std::error::Error>> {
     let mut nonspeech =
         hound::WavWriter::create("tests/.outputs/predict.iter.nonspeech.wav", spec)?;
 
-    let vad = VoiceActivityDetector::<256>::try_with_sample_rate(spec.sample_rate)?;
+    let vad = VoiceActivityDetector::builder()
+        .chunk_size(256usize)
+        .sample_rate(spec.sample_rate)
+        .build()?;
 
     let chunks = reader.samples::<i16>().map_while(Result::ok).predict(vad);
 

--- a/tests/file_predict_stream.rs
+++ b/tests/file_predict_stream.rs
@@ -12,7 +12,10 @@ async fn wave_file_predict_stream() -> Result<(), Box<dyn std::error::Error>> {
     let mut nonspeech =
         hound::WavWriter::create("tests/.outputs/predict.stream.nonspeech.wav", spec)?;
 
-    let vad = VoiceActivityDetector::<256>::try_with_sample_rate(spec.sample_rate)?;
+    let vad = VoiceActivityDetector::builder()
+        .chunk_size(256usize)
+        .sample_rate(spec.sample_rate)
+        .build()?;
 
     let chunks = reader.samples::<i16>().map_while(Result::ok);
     let mut chunks = tokio_stream::iter(chunks).predict(vad);


### PR DESCRIPTION
Address Issue #9.

- Removes all of the const generics for the chunk size
- Replaces all of the arrays with Vecs
- Adds a builder to the VAD in order to avoid any confusion with the order of arguments for sample rate and chunk size. Also provides flexibility to add additional configuration options in the future without a breaking change.

The only real change to consumers is on construction of the VAD:
What was this:
```rust
let mut vad = VoiceActivityDetector::<512>::try_with_sample_rate(8000)?;
```
will now be written as:
```rust
let mut vad = VoiceActivityDetector::builder()
    .sample_rate(8000)
    .chunk_size(512usize)
    .build()?;
```