### PR TITLE
fix(deps): lock ort and ort-sys to =2.0.0-rc.9 to avoid build failures.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "itertools",
  "ndarray",
  "ort",
+ "ort-sys",
  "pin-project",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,25 @@ include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 [dependencies]
 futures = "0.3.31"
 ndarray = "0.16.1"
-ort = { version = "2.0.0-rc.9", features = ["ndarray"] }
 pin-project = "1.1.10"
 thiserror = "^2"
 typed-builder = "0.20.1"
+
+# Lock the 'ort' dependency to exactly version 2.0.0-rc.9
+# Reason:
+# When specifying version = "2.0.0-rc.9" without the '=' sign,
+# Cargo treats it as a caret requirement (^2.0.0-rc.9), which includes pre-release versions like rc.10.
+# If a newer pre-release (e.g., 2.0.0-rc.10) exists, Cargo may auto-upgrade to it.
+# However, rc.10 introduces changes that cause this project to fail to compile.
+# Using '=2.0.0-rc.9' ensures that Cargo installs exactly this version, avoiding unexpected breakage.
+[dependencies.ort]
+version = "=2.0.0-rc.9"
+features = ["ndarray"]
+
+# Similarly, lock 'ort-sys' to the same exact version.
+# This ensures consistency and prevents indirect upgrades that could lead to version mismatches or build issues.
+[dependencies.ort-sys]
+version = "=2.0.0-rc.9"
 
 [dev-dependencies]
 hound = "3.5.1"


### PR DESCRIPTION
By default, specifying version = "2.0.0-rc.9" allows Cargo to auto-upgrade to compatible pre-release versions like 2.0.0-rc.10.

However, 2.0.0-rc.10 introduces changes that cause this project to fail to compile.

This commit explicitly locks both `ort` and `ort-sys` to version =2.0.0-rc.9 to prevent such automatic upgrades and ensure a stable build.

According to the Semantic Versioning 2.0.0 spec (https://semver.org/), pre-release versions are considered lower precedence than their corresponding release, but version ranges still allow newer pre-releases unless locked with an '='.